### PR TITLE
Update base58-go to v0.1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.1
 
 require (
 	github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec
-	github.com/koba-e964/base58-go v0.1.1
+	github.com/koba-e964/base58-go v0.1.2
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/crypto v0.45.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec h1:1Qb69m
 github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec/go.mod h1:CD8UlnlLDiqb36L110uqiP2iSflVjx9g/3U9hCI4q2U=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/koba-e964/base58-go v0.1.1 h1:E6nyuLv6tmjTmBNK5r8g2WPtSgs0vP44ygMt4JSGeGs=
-github.com/koba-e964/base58-go v0.1.1/go.mod h1:0uOSVP8oWX073Mfg5lDuOnE/PAI3cdb8sCfW24NMMMA=
+github.com/koba-e964/base58-go v0.1.2 h1:NNh237YDcha9o0s+gRqUuV2WhrYfEojE5+oIbNe5qg4=
+github.com/koba-e964/base58-go v0.1.2/go.mod h1:0uOSVP8oWX073Mfg5lDuOnE/PAI3cdb8sCfW24NMMMA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=


### PR DESCRIPTION
## Summary
  - bump github.com/koba-e964/base58-go to v0.1.2
  - refresh go.sum to match the new version