### PR TITLE
Add pre-commit hooks for gofmt and staticcheck

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/TekWizely/pre-commit-golang
+    rev: f298c082154b2cb239fac06a4f452368e66e66dd # v1.0.0-rc.4
+    hooks:
+      - id: go-fmt
+        args: ["-w"]
+      - id: go-staticcheck-repo-mod

--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ func main() {
 
 ## Documentation
 Package info: [https://pkg.go.dev/github.com/koba-e964/bip32-typesafe](https://pkg.go.dev/github.com/koba-e964/bip32-typesafe)
+
+## Development
+This repo uses pre-commit to run `gofmt` and `staticcheck` before each commit.
+
+```sh
+pre-commit install
+pre-commit run --all-files
+```


### PR DESCRIPTION
## Summary
- add repo-pinned pre-commit hooks for gofmt and staticcheck
- document pre-commit usage in README

## Testing
- pre-commit run --all-files